### PR TITLE
Fix autostart, improve font config, add proper mouse support

### DIFF
--- a/src/nativeMain/kotlin/Config.kt
+++ b/src/nativeMain/kotlin/Config.kt
@@ -9,7 +9,7 @@ data class Config(
 
 @Serializable
 data class General(
-    val autoStartPath: String = ".config/prism/autostart",
+    val autoStartPath: String = "~/.config/prism/autostart",
 )
 
 @Serializable

--- a/src/nativeMain/kotlin/Config.kt
+++ b/src/nativeMain/kotlin/Config.kt
@@ -17,6 +17,7 @@ data class Header(
     val color: String = "#ffffff",
     val textColor: String = "#000000",
     val font: String = "DejaVu Sans Mono:size=12",
+    val fontSize: Long = 12,
     val height: Long = 30,
     val items: List<Item> = emptyList()
 )

--- a/src/nativeMain/kotlin/Prism.kt
+++ b/src/nativeMain/kotlin/Prism.kt
@@ -43,7 +43,7 @@ class Prism(
 
         while (true) {
             dpy.nextEvent(event.ptr)
-            root.setCursor(dpy, 58.toUInt()) // https://tronche.com/gui/x/xlib/appendix/b/
+            root.setCursor(dpy, 58u) // https://tronche.com/gui/x/xlib/appendix/b/
             // root.unsetCursor(dpy)         // your DE will replace these cursors with its own
             when (event.type) {              // TODO: When should we set the root window cursor? When should we unset it?
                 MapRequest -> event.xmaprequest.run {

--- a/src/nativeMain/kotlin/Prism.kt
+++ b/src/nativeMain/kotlin/Prism.kt
@@ -6,7 +6,7 @@ import kotlin.system.exitProcess
 
 class Prism(
     private val config: Config,
-    private val dpy: Display
+    private val dpy: Display,
 ) {
     private val clients = mutableListOf<Client>()
     private var motionInfo: MotionInfo? = null
@@ -43,8 +43,9 @@ class Prism(
 
         while (true) {
             dpy.nextEvent(event.ptr)
-
-            when (event.type) {
+            root.setCursor(dpy, 58.toUInt()) // https://tronche.com/gui/x/xlib/appendix/b/
+            // root.unsetCursor(dpy)         // your DE will replace these cursors with its own
+            when (event.type) {              // TODO: When should we set the root window cursor? When should we unset it?
                 MapRequest -> event.xmaprequest.run {
                     memScoped {
                         val attrs = dpy.getWindowAttributes(window)
@@ -234,6 +235,7 @@ class Prism(
                     )
                 }
                 MotionNotify -> if (motionInfo != null) event.xmotion.run {
+
                     val client = clients.find { it.container == window || it.header == window } ?: return@run
 
                     while (XCheckTypedEvent(dpy.ptr, MotionNotify, event.ptr) == True) Unit

--- a/src/nativeMain/kotlin/Prism.kt
+++ b/src/nativeMain/kotlin/Prism.kt
@@ -6,7 +6,7 @@ import kotlin.system.exitProcess
 
 class Prism(
     private val config: Config,
-    private val dpy: Display,
+    private val dpy: Display
 ) {
     private val clients = mutableListOf<Client>()
     private var motionInfo: MotionInfo? = null

--- a/src/nativeMain/kotlin/Prism.kt
+++ b/src/nativeMain/kotlin/Prism.kt
@@ -134,7 +134,7 @@ class Prism(
                                 } as CPointerVar<ByteVar>).value?.toKString() ?: fetchedName.value?.toKString() ?: "Unknown name"
 
                                 val draw = XftDrawCreate(dpy.ptr, header, attrs.visual, attrs.colormap)
-                                val font = XftFontOpenName(dpy.ptr, 0, config.header.font)
+                                val font = XftFontOpenName(dpy.ptr, 0, "${config.header.font}:size=${config.header.fontSize}")
                                 val color = alloc<XftColor> {
                                     XftColorAllocName(dpy.ptr, attrs.visual, attrs.colormap, config.header.textColor, ptr)
                                 }

--- a/src/nativeMain/kotlin/util/Util.kt
+++ b/src/nativeMain/kotlin/util/Util.kt
@@ -34,7 +34,7 @@ fun Display.sendClientMessage(type: Atom, window: Window, propagate: Boolean = f
 fun Display.sendClientMessage(type: Atom, propagate: Boolean = false, eventMask: Long = NoEventMask, vararg data: Long) =
     sendClientMessage(type, rootWindow, propagate, eventMask, *data)
 
-fun Window.setCursor(dpy: Display, cur: UInt = 2.toUInt()) { 
+fun Window.setCursor(dpy: Display, cur: UInt = 2u) { 
     var cursorInitialized = windowCursorInitialized[this]
     if (cursorInitialized != true) {
         XDefineCursor(dpy.ptr, this, XCreateFontCursor(dpy.ptr, cur))

--- a/src/nativeMain/kotlin/util/Util.kt
+++ b/src/nativeMain/kotlin/util/Util.kt
@@ -34,14 +34,14 @@ fun Display.sendClientMessage(type: Atom, window: Window, propagate: Boolean = f
 fun Display.sendClientMessage(type: Atom, propagate: Boolean = false, eventMask: Long = NoEventMask, vararg data: Long) =
     sendClientMessage(type, rootWindow, propagate, eventMask, *data)
 
-public fun Window.setCursor(dpy: Display, cur: UInt = 2.toUInt()) { 
+fun Window.setCursor(dpy: Display, cur: UInt = 2.toUInt()) { 
     var cursorInitialized = windowCursorInitialized[this]
     if (cursorInitialized != true) {
         XDefineCursor(dpy.ptr, this, XCreateFontCursor(dpy.ptr, cur))
         windowCursorInitialized.put(this, true)
     }
 }
-public fun Window.unsetCursor(dpy: Display) {
+fun Window.unsetCursor(dpy: Display) {
     XUndefineCursor(dpy.ptr, this)
     windowCursorInitialized.put(this, false)
 }

--- a/src/nativeMain/kotlin/util/Util.kt
+++ b/src/nativeMain/kotlin/util/Util.kt
@@ -48,5 +48,6 @@ fun Window.unsetCursor(dpy: Display, window: Window = this) {
     windowCursorInitialized.put(window, false)
 }
 // TODO: Does this work with window focus?
-// 
+// Should these be part of Window if they can be used on windows other than themselves?
+// Or should `window` be removed and replaced with `this`?
 // https://tronche.com/gui/x/xlib/window/XUndefineCursor.html

--- a/src/nativeMain/kotlin/util/Util.kt
+++ b/src/nativeMain/kotlin/util/Util.kt
@@ -10,7 +10,6 @@ import xlib.*
 
 fun getConfigDir(): String? = getenv("XDG_CONFIG_HOME")?.toKString() ?: getenv("HOME")?.toKString()?.plus("/.config")
 fun Boolean.toInt(): Int = if (this) 1 else 0
-var windowCursors: MutableMap<Window, Cursor> = mutableMapOf()
 var windowCursorInitialized: MutableMap<Window, Boolean> = mutableMapOf()
 
 fun Display.sendClientMessage(type: Atom, window: Window, propagate: Boolean = false, eventMask: Long = NoEventMask, vararg data: Long) {
@@ -35,19 +34,16 @@ fun Display.sendClientMessage(type: Atom, window: Window, propagate: Boolean = f
 fun Display.sendClientMessage(type: Atom, propagate: Boolean = false, eventMask: Long = NoEventMask, vararg data: Long) =
     sendClientMessage(type, rootWindow, propagate, eventMask, *data)
 
-fun Window.setCursor(dpy: Display, cur: UInt = 2.toUInt(), window: Window = this) { 
-    var cursorInitialized = windowCursorInitialized[window]
+public fun Window.setCursor(dpy: Display, cur: UInt = 2.toUInt()) { 
+    var cursorInitialized = windowCursorInitialized[this]
     if (cursorInitialized != true) {
-        windowCursors.put(window, XCreateFontCursor(dpy.ptr, cur))
-        XDefineCursor(dpy.ptr, window, windowCursors[window]!!)
-        windowCursorInitialized.put(window, true)
+        XDefineCursor(dpy.ptr, this, XCreateFontCursor(dpy.ptr, cur))
+        windowCursorInitialized.put(this, true)
     }
 }
-fun Window.unsetCursor(dpy: Display, window: Window = this) {
-    XUndefineCursor(dpy.ptr, window)
-    windowCursorInitialized.put(window, false)
+public fun Window.unsetCursor(dpy: Display) {
+    XUndefineCursor(dpy.ptr, this)
+    windowCursorInitialized.put(this, false)
 }
 // TODO: Does this work with window focus?
-// Should these be part of Window if they can be used on windows other than themselves?
-// Or should `window` be removed and replaced with `this`?
 // https://tronche.com/gui/x/xlib/window/XUndefineCursor.html


### PR DESCRIPTION
This ensures that the home directory is checked by default for the autostart file, and separates the font size from the font key in the config. Also adds window.setCursor and window.unsetCursor methods for graphical cursor management.