### PR TITLE
Add libxcrypt-compat to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install dependencies using your system package manager.
 
 | Distro               | Dependencies                                                               |
 |----------------------|----------------------------------------------------------------------------|
-| Arch Linux           | glibc libx11 libxft libxpm freetype2                                       |
+| Arch Linux           | glibc libx11 libxft libxpm freetype2 libxcrypt-compat                      |
 | Debian (Ubuntu, etc) | libc6-dev libx11-dev libxft-dev libxpm-dev libfreetype-dev build-essential |
 
 You should now be able to run `./gradlew build` to build Prism.<br>


### PR DESCRIPTION
Required for libcrypt.so.1 on Arch